### PR TITLE
Fix for single level groups not spawning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.1.3
+Fixed regression on single level menu spawning caused by multi-menu code
+
 ## v0.1.2
 Fixes for multi-level menus when duplicate branches exist below the first level.
 

--- a/dssm.lua
+++ b/dssm.lua
@@ -1,6 +1,6 @@
 -- DCS Simple Spawn Menu
 -- Created by Popper
--- v0.1.2
+-- v0.1.3
 -- Updated for multimenu handling by Gillogical
 -- Repository: https://github.com/Markoudstaal/DCS-Simple-Spawn-Menu
 -- License: MIT
@@ -269,7 +269,9 @@ end
 -- Creates a set of submenus from a getStringToIdentifier setup
 local function createMultiMenus(name, parentMenu, curGroupDBName)
     if countTableSize(name) == 0 then
-        return nil
+        myLogger:msg('Table Size zero, STOP $1| Group $2', parentMenu, curGroupDBName)
+		addToMenu(curGroupDBName, parentMenu)
+		return nil
     else
         for k, v in pairs(name) do
             local menu = missionCommands.addSubMenu(k, parentMenu)


### PR DESCRIPTION
Fixed issue where a group of one level "!?Level1?*Group1*!Tanks" would not get the spawn/despawn menu items